### PR TITLE
decouple ref formulation

### DIFF
--- a/carml-engine/src/main/java/com/taxonic/carml/engine/EvaluateExpression.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/EvaluateExpression.java
@@ -3,6 +3,6 @@ package com.taxonic.carml.engine;
 import java.util.Optional;
 import java.util.function.Function;
 
-interface EvaluateExpression extends Function<String, Optional<Object>> {
+public interface EvaluateExpression extends Function<String, Optional<Object>> {
 
 }

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
@@ -11,18 +11,18 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
-class ParentTriplesMapper<SourceType> {
+class ParentTriplesMapper<T> {
 	
 	private TermGenerator<Resource> subjectGenerator;
 
-	private Supplier<Iterable<SourceType>> getIterator;
-	private LogicalSourceResolver.ExpressionEvaluatorFactory<SourceType> expressionEvaluatorFactory;
+	private Supplier<Iterable<T>> getIterator;
+	private LogicalSourceResolver.ExpressionEvaluatorFactory<T> expressionEvaluatorFactory;
 
 		ParentTriplesMapper(
 			TermGenerator<Resource> subjectGenerator,
 
-			Supplier<Iterable<SourceType>> getIterator,
-			LogicalSourceResolver.ExpressionEvaluatorFactory<SourceType> expressionEvaluatorFactory
+			Supplier<Iterable<T>> getIterator,
+			LogicalSourceResolver.ExpressionEvaluatorFactory<T> expressionEvaluatorFactory
 	) {
 		this.subjectGenerator = subjectGenerator;
 		this.getIterator = getIterator;
@@ -38,7 +38,7 @@ class ParentTriplesMapper<SourceType> {
 		return results;
 	}
 	
-	private Optional<Resource> map(SourceType entry, Map<String, Object> joinValues) {
+	private Optional<Resource> map(T entry, Map<String, Object> joinValues) {
 		// example of joinValues: key: "$.country.name", value: "Belgium"
 		EvaluateExpression evaluate =
 			expressionEvaluatorFactory.apply(entry);

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
@@ -1,6 +1,6 @@
 package com.taxonic.carml.engine;
 
-import com.taxonic.carml.resolvers.LogicalSourceResolver;
+import com.taxonic.carml.logical_source_resolver.LogicalSourceResolver;
 
 import org.eclipse.rdf4j.model.Resource;
 

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
@@ -1,55 +1,44 @@
 package com.taxonic.carml.engine;
 
-import java.util.Collections;
+import com.taxonic.carml.resolvers.LogicalSourceResolver;
+
+import org.eclipse.rdf4j.model.Resource;
+
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 
-import org.eclipse.rdf4j.model.Resource;
-
-class ParentTriplesMapper {
+class ParentTriplesMapper<SourceType> {
 	
 	private TermGenerator<Resource> subjectGenerator;
-	private Supplier<Object> getSource;
-	private UnaryOperator<Object> applyIterator;
-	private Function<Object, EvaluateExpression> expressionEvaluatorFactory;
-	
-	ParentTriplesMapper(
-		TermGenerator<Resource> subjectGenerator,
-		Supplier<Object> getSource,
-		UnaryOperator<Object> applyIterator,
-		Function<Object, EvaluateExpression> expressionEvaluatorFactory
+
+	private Supplier<Iterable<SourceType>> getIterator;
+	private LogicalSourceResolver.ExpressionEvaluatorFactory<SourceType> expressionEvaluatorFactory;
+
+		ParentTriplesMapper(
+			TermGenerator<Resource> subjectGenerator,
+
+			Supplier<Iterable<SourceType>> getIterator,
+			LogicalSourceResolver.ExpressionEvaluatorFactory<SourceType> expressionEvaluatorFactory
 	) {
 		this.subjectGenerator = subjectGenerator;
-		this.getSource = getSource;
-		this.applyIterator = applyIterator;
+		this.getIterator = getIterator;
 		this.expressionEvaluatorFactory = expressionEvaluatorFactory;
 	}
-
-	private Iterable<?> createIterable(Object value) {
-		boolean isIterable = Iterable.class.isAssignableFrom(value.getClass());
-		return isIterable
-			? (Iterable<?>) value
-			: Collections.singleton(value);
-	}
 	
+
 	Set<Resource> map(Map<String, Object> joinValues) {
-		Object source = getSource.get();
-		Object value = applyIterator.apply(source);
-		Iterable<?> iterable = createIterable(value);
 		Set<Resource> results = new LinkedHashSet<>();
-		iterable.forEach(e -> 
+		getIterator.get().forEach(e ->
 			map(e, joinValues)
 				.ifPresent(results::add));
 		return results;
 	}
 	
-	private Optional<Resource> map(Object entry, Map<String, Object> joinValues) {
+	private Optional<Resource> map(SourceType entry, Map<String, Object> joinValues) {
 		// example of joinValues: key: "$.country.name", value: "Belgium"
 		EvaluateExpression evaluate =
 			expressionEvaluatorFactory.apply(entry);

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/RmlMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/RmlMapper.java
@@ -371,7 +371,7 @@ public class RmlMapper {
 		);
 	}
 	
-	private static class TriplesMapperComponents<T> {
+	static class TriplesMapperComponents<T> {
 		
 		LogicalSourceResolver<T> logicalSourceResolver;
 		private final InputStream source;
@@ -392,7 +392,7 @@ public class RmlMapper {
 		}
 	}
 
-	private TriplesMapperComponents getTriplesMapperComponents(TriplesMap triplesMap) {
+	TriplesMapperComponents getTriplesMapperComponents(TriplesMap triplesMap) {
 		
 		LogicalSource logicalSource = triplesMap.getLogicalSource();
 

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/RmlMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/RmlMapper.java
@@ -135,7 +135,7 @@ public class RmlMapper {
 			RmlMapper mapper =
 				new RmlMapper(
 					new CompositeSourceResolver(
-						// prepend carml stream resolver to regular logical_source_resolver
+						// prepend carml stream resolver to regular resolvers
 						Stream.concat(
 							Stream.of(carmlStreamResolver),
 							sourceResolvers.stream()

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/TriplesMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/TriplesMapper.java
@@ -1,6 +1,6 @@
 package com.taxonic.carml.engine;
 
-import com.taxonic.carml.resolvers.LogicalSourceResolver;
+import com.taxonic.carml.logical_source_resolver.LogicalSourceResolver;
 
 import java.util.function.Supplier;
 

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/TriplesMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/TriplesMapper.java
@@ -1,48 +1,32 @@
 package com.taxonic.carml.engine;
 
-import java.util.Collections;
-import java.util.function.Function;
+import com.taxonic.carml.resolvers.LogicalSourceResolver;
+
 import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 
 import org.eclipse.rdf4j.model.Model;
 
-class TriplesMapper {
+class TriplesMapper<SourceType> {
 	
-	private Supplier<Object> getSource;
-	private UnaryOperator<Object> applyIterator;
-	private Function<Object, EvaluateExpression> expressionEvaluatorFactory;
+	private Supplier<Iterable<SourceType>> getIterator;
+	private LogicalSourceResolver.ExpressionEvaluatorFactory<SourceType> expressionEvaluatorFactory;
 	private SubjectMapper subjectMapper;
 	
 	TriplesMapper(
-		Supplier<Object> getSource,
-		UnaryOperator<Object> applyIterator,
-		Function<Object, EvaluateExpression> expressionEvaluatorFactory,
+		Supplier<Iterable<SourceType>> getIterator,
+		LogicalSourceResolver.ExpressionEvaluatorFactory<SourceType> expressionEvaluatorFactory,
 		SubjectMapper subjectMapper
 	) {
-		this.getSource = getSource;
-		this.applyIterator = applyIterator;
+		this.getIterator = getIterator;
 		this.expressionEvaluatorFactory = expressionEvaluatorFactory;
 		this.subjectMapper = subjectMapper;
 	}
-
-	private Iterable<?> createIterable(Object value) {
-		if (value == null)
-			return Collections.emptyList();
-		boolean isIterable = value instanceof Iterable;
-		return isIterable
-			? (Iterable<?>) value
-			: Collections.singleton(value);
-	}
 	
 	void map(Model model) {
-		Object source = getSource.get();
-		Object value = applyIterator.apply(source);
-		Iterable<?> iterable = createIterable(value);
-		iterable.forEach(e -> map(e, model));
+		getIterator.get().forEach(e -> map(e, model));
 	}
 	
-	private void map(Object entry, Model model) {
+	private void map(SourceType entry, Model model) {
 		EvaluateExpression evaluate =
 			expressionEvaluatorFactory.apply(entry);
 		subjectMapper.map(model, evaluate);

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/TriplesMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/TriplesMapper.java
@@ -6,15 +6,15 @@ import java.util.function.Supplier;
 
 import org.eclipse.rdf4j.model.Model;
 
-class TriplesMapper<SourceType> {
+class TriplesMapper<T> {
 	
-	private Supplier<Iterable<SourceType>> getIterator;
-	private LogicalSourceResolver.ExpressionEvaluatorFactory<SourceType> expressionEvaluatorFactory;
+	private Supplier<Iterable<T>> getIterator;
+	private LogicalSourceResolver.ExpressionEvaluatorFactory<T> expressionEvaluatorFactory;
 	private SubjectMapper subjectMapper;
 	
 	TriplesMapper(
-		Supplier<Iterable<SourceType>> getIterator,
-		LogicalSourceResolver.ExpressionEvaluatorFactory<SourceType> expressionEvaluatorFactory,
+		Supplier<Iterable<T>> getIterator,
+		LogicalSourceResolver.ExpressionEvaluatorFactory<T> expressionEvaluatorFactory,
 		SubjectMapper subjectMapper
 	) {
 		this.getIterator = getIterator;
@@ -26,7 +26,7 @@ class TriplesMapper<SourceType> {
 		getIterator.get().forEach(e -> map(e, model));
 	}
 	
-	private void map(SourceType entry, Model model) {
+	private void map(T entry, Model model) {
 		EvaluateExpression evaluate =
 			expressionEvaluatorFactory.apply(entry);
 		subjectMapper.map(model, evaluate);

--- a/carml-engine/src/main/java/com/taxonic/carml/logical_source_resolver/JsonPathResolver.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/logical_source_resolver/JsonPathResolver.java
@@ -1,0 +1,33 @@
+package com.taxonic.carml.logical_source_resolver;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.taxonic.carml.engine.RmlMapper;
+import com.taxonic.carml.util.IoUtils;
+
+import java.util.Collections;
+import java.util.Optional;
+
+public class JsonPathResolver implements LogicalSourceResolver<Object> {
+
+	private static Configuration JSONPATH_CONF = Configuration.builder()
+			.options(Option.DEFAULT_PATH_LEAF_TO_NULL).build();
+
+	public SourceIterator<Object> getSourceIterator() {
+		return (source, iteratorExpression) -> {
+			String s = IoUtils.readAndResetInputStream(source);
+			Object data = JsonPath.using(JSONPATH_CONF).parse(s).read(iteratorExpression);
+
+			boolean isIterable = Iterable.class.isAssignableFrom(data.getClass());
+			return isIterable
+					? (Iterable<Object>) data
+					: Collections.singleton(data);
+		};
+	}
+
+	public ExpressionEvaluatorFactory<Object> getExpressionEvaluatorFactory() {
+		return object -> expression -> Optional.ofNullable(
+				JsonPath.using(JSONPATH_CONF).parse(object).read(expression));
+	}
+}

--- a/carml-engine/src/main/java/com/taxonic/carml/logical_source_resolver/LogicalSourceResolver.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/logical_source_resolver/LogicalSourceResolver.java
@@ -1,7 +1,8 @@
-package com.taxonic.carml.resolvers;
+package com.taxonic.carml.logical_source_resolver;
 
 import com.taxonic.carml.engine.EvaluateExpression;
 
+import java.io.InputStream;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -10,11 +11,11 @@ public interface LogicalSourceResolver<T> {
 	SourceIterator<T> getSourceIterator();
 	ExpressionEvaluatorFactory<T> getExpressionEvaluatorFactory();
 
-	default Supplier<Iterable<T>> bindSource(Object source, String iteratorExpression) {
+	default Supplier<Iterable<T>> bindSource(InputStream source, String iteratorExpression) {
 		return () -> getSourceIterator().apply(source, iteratorExpression);
 	}
 
-	interface SourceIterator<T> extends BiFunction<Object, String, Iterable<T>> {
+	interface SourceIterator<T> extends BiFunction<InputStream, String, Iterable<T>> {
 
 	}
 

--- a/carml-engine/src/main/java/com/taxonic/carml/resolvers/LogicalSourceResolver.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/resolvers/LogicalSourceResolver.java
@@ -6,18 +6,18 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-public abstract class LogicalSourceResolver<SourceType> {
-	public abstract SourceIterator<SourceType> getSourceIterator();
-	public abstract ExpressionEvaluatorFactory<SourceType> getExpressionEvaluatorFactory();
+public interface LogicalSourceResolver<T> {
+	SourceIterator<T> getSourceIterator();
+	ExpressionEvaluatorFactory<T> getExpressionEvaluatorFactory();
 
-	public Supplier<Iterable<SourceType>> bindSource(Object source, String iteratorExpression) {
+	default Supplier<Iterable<T>> bindSource(Object source, String iteratorExpression) {
 		return () -> getSourceIterator().apply(source, iteratorExpression);
 	}
 
-	public interface SourceIterator<SourceType> extends BiFunction<Object, String, Iterable<SourceType>> {
+	interface SourceIterator<T> extends BiFunction<Object, String, Iterable<T>> {
 
 	}
 
-	public interface ExpressionEvaluatorFactory<SourceType> extends Function<SourceType, EvaluateExpression> { }
+	interface ExpressionEvaluatorFactory<T> extends Function<T, EvaluateExpression> { }
 
 }

--- a/carml-engine/src/main/java/com/taxonic/carml/resolvers/LogicalSourceResolver.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/resolvers/LogicalSourceResolver.java
@@ -1,0 +1,23 @@
+package com.taxonic.carml.resolvers;
+
+import com.taxonic.carml.engine.EvaluateExpression;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public abstract class LogicalSourceResolver<SourceType> {
+	public abstract SourceIterator<SourceType> getSourceIterator();
+	public abstract ExpressionEvaluatorFactory<SourceType> getExpressionEvaluatorFactory();
+
+	public Supplier<Iterable<SourceType>> bindSource(Object source, String iteratorExpression) {
+		return () -> getSourceIterator().apply(source, iteratorExpression);
+	}
+
+	public interface SourceIterator<SourceType> extends BiFunction<Object, String, Iterable<SourceType>> {
+
+	}
+
+	public interface ExpressionEvaluatorFactory<SourceType> extends Function<SourceType, EvaluateExpression> { }
+
+}

--- a/carml-engine/src/test/java/com/taxonic/carml/engine/ParentTriplesMapperTest.java
+++ b/carml-engine/src/test/java/com/taxonic/carml/engine/ParentTriplesMapperTest.java
@@ -23,19 +23,18 @@ import org.mockito.junit.MockitoRule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import com.taxonic.carml.resolvers.LogicalSourceResolver;
+
 public class ParentTriplesMapperTest {
 	
 	@Mock
 	private TermGenerator<Resource> subjectGenerator;
 	
 	@Mock
-	private Supplier<Object> getSource;
+	private Supplier<Iterable<Object>> getIterator;
 	
 	@Mock
-	private UnaryOperator<Object> applyIterator;
-	
-	@Mock
-	private Function<Object, EvaluateExpression> expressionEvaluatorFactory;
+	private LogicalSourceResolver.ExpressionEvaluatorFactory expressionEvaluatorFactory;
 	
 	@Rule 
 	public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -57,12 +56,10 @@ public class ParentTriplesMapperTest {
 
 	@Test
 	public void parentTriplesMapper_givenJoinConditions() {
-		when(getSource.get()).thenReturn("");
-		when(applyIterator.apply(""))
-			.thenReturn(ImmutableList.of(entry));
+		when(getIterator.get()).thenReturn(ImmutableList.of(entry));
 		when(expressionEvaluatorFactory.apply(entry)).thenReturn(evaluate);
 		when(subjectGenerator.apply(evaluate)).thenReturn(Optional.of(SKOS.CONCEPT));
-		ParentTriplesMapper mapper = new ParentTriplesMapper(subjectGenerator, getSource, applyIterator, expressionEvaluatorFactory);
+		ParentTriplesMapper mapper = new ParentTriplesMapper(subjectGenerator, getIterator, expressionEvaluatorFactory);
 		Set<Resource> resources = mapper.map(joinValues);
 		assertThat(resources.size(), is(1));
 		assertThat(SKOS.CONCEPT, isIn(resources));

--- a/carml-engine/src/test/java/com/taxonic/carml/engine/ParentTriplesMapperTest.java
+++ b/carml-engine/src/test/java/com/taxonic/carml/engine/ParentTriplesMapperTest.java
@@ -8,9 +8,7 @@ import static org.mockito.Mockito.when;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.vocabulary.SKOS;
@@ -23,7 +21,7 @@ import org.mockito.junit.MockitoRule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import com.taxonic.carml.resolvers.LogicalSourceResolver;
+import com.taxonic.carml.logical_source_resolver.LogicalSourceResolver;
 
 public class ParentTriplesMapperTest {
 	

--- a/carml-engine/src/test/java/com/taxonic/carml/engine/iotests/MappingTest.java
+++ b/carml-engine/src/test/java/com/taxonic/carml/engine/iotests/MappingTest.java
@@ -48,7 +48,9 @@ class MappingTest {
 		Consumer<RmlMapper> configureMapperInstance
 	) {
 		Set<TriplesMap> mapping = loader.load(rmlPath, RDFFormat.TURTLE);
-		RmlMapper.Builder builder = RmlMapper.newBuilder().classPathResolver(contextPath);
+		RmlMapper.Builder builder = RmlMapper.newBuilder()
+				.addDefaultLogicalSourceResolvers()
+				.classPathResolver(contextPath);
 		configureMapper.accept(builder);
 		RmlMapper mapper = builder.build();
 		configureMapperInstance.accept(mapper);


### PR DESCRIPTION
RmlMapper now dynamically chooses a ReferenceFormulationImplementation based on the `rml:refFormulation` in the logical source. This decouples the JsonPath code from the rml mapper, and allows users to add support for their own source data types.