### PR TITLE
Xpath support

### DIFF
--- a/carml-engine/src/main/java/com/taxonic/carml/engine/EvaluateExpression.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/EvaluateExpression.java
@@ -3,6 +3,6 @@ package com.taxonic.carml.engine;
 import java.util.Optional;
 import java.util.function.Function;
 
-interface EvaluateExpression extends Function<String, Optional<Object>> {
+public interface EvaluateExpression extends Function<String, Optional<Object>> {
 
 }

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
@@ -11,18 +11,18 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
-class ParentTriplesMapper<SourceType> {
+class ParentTriplesMapper<T> {
 	
 	private TermGenerator<Resource> subjectGenerator;
 
-	private Supplier<Iterable<SourceType>> getIterator;
-	private LogicalSourceResolver.ExpressionEvaluatorFactory<SourceType> expressionEvaluatorFactory;
+	private Supplier<Iterable<T>> getIterator;
+	private LogicalSourceResolver.ExpressionEvaluatorFactory<T> expressionEvaluatorFactory;
 
 		ParentTriplesMapper(
 			TermGenerator<Resource> subjectGenerator,
 
-			Supplier<Iterable<SourceType>> getIterator,
-			LogicalSourceResolver.ExpressionEvaluatorFactory<SourceType> expressionEvaluatorFactory
+			Supplier<Iterable<T>> getIterator,
+			LogicalSourceResolver.ExpressionEvaluatorFactory<T> expressionEvaluatorFactory
 	) {
 		this.subjectGenerator = subjectGenerator;
 		this.getIterator = getIterator;
@@ -38,7 +38,7 @@ class ParentTriplesMapper<SourceType> {
 		return results;
 	}
 	
-	private Optional<Resource> map(SourceType entry, Map<String, Object> joinValues) {
+	private Optional<Resource> map(T entry, Map<String, Object> joinValues) {
 		// example of joinValues: key: "$.country.name", value: "Belgium"
 		EvaluateExpression evaluate =
 			expressionEvaluatorFactory.apply(entry);

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
@@ -1,6 +1,6 @@
 package com.taxonic.carml.engine;
 
-import com.taxonic.carml.resolvers.LogicalSourceResolver;
+import com.taxonic.carml.logical_source_resolver.LogicalSourceResolver;
 
 import org.eclipse.rdf4j.model.Resource;
 

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
@@ -1,55 +1,44 @@
 package com.taxonic.carml.engine;
 
-import java.util.Collections;
+import com.taxonic.carml.resolvers.LogicalSourceResolver;
+
+import org.eclipse.rdf4j.model.Resource;
+
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 
-import org.eclipse.rdf4j.model.Resource;
-
-class ParentTriplesMapper {
+class ParentTriplesMapper<SourceType> {
 	
 	private TermGenerator<Resource> subjectGenerator;
-	private Supplier<Object> getSource;
-	private UnaryOperator<Object> applyIterator;
-	private Function<Object, EvaluateExpression> expressionEvaluatorFactory;
-	
-	ParentTriplesMapper(
-		TermGenerator<Resource> subjectGenerator,
-		Supplier<Object> getSource,
-		UnaryOperator<Object> applyIterator,
-		Function<Object, EvaluateExpression> expressionEvaluatorFactory
+
+	private Supplier<Iterable<SourceType>> getIterator;
+	private LogicalSourceResolver.ExpressionEvaluatorFactory<SourceType> expressionEvaluatorFactory;
+
+		ParentTriplesMapper(
+			TermGenerator<Resource> subjectGenerator,
+
+			Supplier<Iterable<SourceType>> getIterator,
+			LogicalSourceResolver.ExpressionEvaluatorFactory<SourceType> expressionEvaluatorFactory
 	) {
 		this.subjectGenerator = subjectGenerator;
-		this.getSource = getSource;
-		this.applyIterator = applyIterator;
+		this.getIterator = getIterator;
 		this.expressionEvaluatorFactory = expressionEvaluatorFactory;
 	}
-
-	private Iterable<?> createIterable(Object value) {
-		boolean isIterable = Iterable.class.isAssignableFrom(value.getClass());
-		return isIterable
-			? (Iterable<?>) value
-			: Collections.singleton(value);
-	}
 	
+
 	Set<Resource> map(Map<String, Object> joinValues) {
-		Object source = getSource.get();
-		Object value = applyIterator.apply(source);
-		Iterable<?> iterable = createIterable(value);
 		Set<Resource> results = new LinkedHashSet<>();
-		iterable.forEach(e -> 
+		getIterator.get().forEach(e ->
 			map(e, joinValues)
 				.ifPresent(results::add));
 		return results;
 	}
 	
-	private Optional<Resource> map(Object entry, Map<String, Object> joinValues) {
+	private Optional<Resource> map(SourceType entry, Map<String, Object> joinValues) {
 		// example of joinValues: key: "$.country.name", value: "Belgium"
 		EvaluateExpression evaluate =
 			expressionEvaluatorFactory.apply(entry);

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/RmlMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/RmlMapper.java
@@ -371,7 +371,7 @@ public class RmlMapper {
 		);
 	}
 	
-	private static class TriplesMapperComponents<T> {
+	static class TriplesMapperComponents<T> {
 		
 		LogicalSourceResolver<T> logicalSourceResolver;
 		private final InputStream source;
@@ -392,7 +392,7 @@ public class RmlMapper {
 		}
 	}
 
-	private TriplesMapperComponents getTriplesMapperComponents(TriplesMap triplesMap) {
+	TriplesMapperComponents getTriplesMapperComponents(TriplesMap triplesMap) {
 		
 		LogicalSource logicalSource = triplesMap.getLogicalSource();
 

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/RmlMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/RmlMapper.java
@@ -135,7 +135,7 @@ public class RmlMapper {
 			RmlMapper mapper =
 				new RmlMapper(
 					new CompositeSourceResolver(
-						// prepend carml stream resolver to regular logical_source_resolver
+						// prepend carml stream resolver to regular resolvers
 						Stream.concat(
 							Stream.of(carmlStreamResolver),
 							sourceResolvers.stream()

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/RmlMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/RmlMapper.java
@@ -4,6 +4,7 @@ import com.taxonic.carml.engine.function.ExecuteFunction;
 import com.taxonic.carml.engine.function.Functions;
 import com.taxonic.carml.logical_source_resolver.JsonPathResolver;
 import com.taxonic.carml.logical_source_resolver.LogicalSourceResolver;
+import com.taxonic.carml.logical_source_resolver.XPathResolver;
 import com.taxonic.carml.model.BaseObjectMap;
 import com.taxonic.carml.model.GraphMap;
 import com.taxonic.carml.model.Join;
@@ -83,6 +84,7 @@ public class RmlMapper {
 
 		public Builder addDefaultLogicalSourceResolvers() {
 			this.logicalSourceResolvers.put(Rdf.Ql.JsonPath, new JsonPathResolver());
+			this.logicalSourceResolvers.put(Rdf.Ql.XPath, new XPathResolver());
 			return this;
 		}
 

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/TriplesMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/TriplesMapper.java
@@ -1,6 +1,6 @@
 package com.taxonic.carml.engine;
 
-import com.taxonic.carml.resolvers.LogicalSourceResolver;
+import com.taxonic.carml.logical_source_resolver.LogicalSourceResolver;
 
 import java.util.function.Supplier;
 

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/TriplesMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/TriplesMapper.java
@@ -1,48 +1,32 @@
 package com.taxonic.carml.engine;
 
-import java.util.Collections;
-import java.util.function.Function;
+import com.taxonic.carml.resolvers.LogicalSourceResolver;
+
 import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 
 import org.eclipse.rdf4j.model.Model;
 
-class TriplesMapper {
+class TriplesMapper<SourceType> {
 	
-	private Supplier<Object> getSource;
-	private UnaryOperator<Object> applyIterator;
-	private Function<Object, EvaluateExpression> expressionEvaluatorFactory;
+	private Supplier<Iterable<SourceType>> getIterator;
+	private LogicalSourceResolver.ExpressionEvaluatorFactory<SourceType> expressionEvaluatorFactory;
 	private SubjectMapper subjectMapper;
 	
 	TriplesMapper(
-		Supplier<Object> getSource,
-		UnaryOperator<Object> applyIterator,
-		Function<Object, EvaluateExpression> expressionEvaluatorFactory,
+		Supplier<Iterable<SourceType>> getIterator,
+		LogicalSourceResolver.ExpressionEvaluatorFactory<SourceType> expressionEvaluatorFactory,
 		SubjectMapper subjectMapper
 	) {
-		this.getSource = getSource;
-		this.applyIterator = applyIterator;
+		this.getIterator = getIterator;
 		this.expressionEvaluatorFactory = expressionEvaluatorFactory;
 		this.subjectMapper = subjectMapper;
 	}
-
-	private Iterable<?> createIterable(Object value) {
-		if (value == null)
-			return Collections.emptyList();
-		boolean isIterable = value instanceof Iterable;
-		return isIterable
-			? (Iterable<?>) value
-			: Collections.singleton(value);
-	}
 	
 	void map(Model model) {
-		Object source = getSource.get();
-		Object value = applyIterator.apply(source);
-		Iterable<?> iterable = createIterable(value);
-		iterable.forEach(e -> map(e, model));
+		getIterator.get().forEach(e -> map(e, model));
 	}
 	
-	private void map(Object entry, Model model) {
+	private void map(SourceType entry, Model model) {
 		EvaluateExpression evaluate =
 			expressionEvaluatorFactory.apply(entry);
 		subjectMapper.map(model, evaluate);

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/TriplesMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/TriplesMapper.java
@@ -6,15 +6,15 @@ import java.util.function.Supplier;
 
 import org.eclipse.rdf4j.model.Model;
 
-class TriplesMapper<SourceType> {
+class TriplesMapper<T> {
 	
-	private Supplier<Iterable<SourceType>> getIterator;
-	private LogicalSourceResolver.ExpressionEvaluatorFactory<SourceType> expressionEvaluatorFactory;
+	private Supplier<Iterable<T>> getIterator;
+	private LogicalSourceResolver.ExpressionEvaluatorFactory<T> expressionEvaluatorFactory;
 	private SubjectMapper subjectMapper;
 	
 	TriplesMapper(
-		Supplier<Iterable<SourceType>> getIterator,
-		LogicalSourceResolver.ExpressionEvaluatorFactory<SourceType> expressionEvaluatorFactory,
+		Supplier<Iterable<T>> getIterator,
+		LogicalSourceResolver.ExpressionEvaluatorFactory<T> expressionEvaluatorFactory,
 		SubjectMapper subjectMapper
 	) {
 		this.getIterator = getIterator;
@@ -26,7 +26,7 @@ class TriplesMapper<SourceType> {
 		getIterator.get().forEach(e -> map(e, model));
 	}
 	
-	private void map(SourceType entry, Model model) {
+	private void map(T entry, Model model) {
 		EvaluateExpression evaluate =
 			expressionEvaluatorFactory.apply(entry);
 		subjectMapper.map(model, evaluate);

--- a/carml-engine/src/main/java/com/taxonic/carml/logical_source_resolver/JsonPathResolver.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/logical_source_resolver/JsonPathResolver.java
@@ -1,0 +1,33 @@
+package com.taxonic.carml.logical_source_resolver;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.taxonic.carml.engine.RmlMapper;
+import com.taxonic.carml.util.IoUtils;
+
+import java.util.Collections;
+import java.util.Optional;
+
+public class JsonPathResolver implements LogicalSourceResolver<Object> {
+
+	private static Configuration JSONPATH_CONF = Configuration.builder()
+			.options(Option.DEFAULT_PATH_LEAF_TO_NULL).build();
+
+	public SourceIterator<Object> getSourceIterator() {
+		return (source, iteratorExpression) -> {
+			String s = IoUtils.readAndResetInputStream(source);
+			Object data = JsonPath.using(JSONPATH_CONF).parse(s).read(iteratorExpression);
+
+			boolean isIterable = Iterable.class.isAssignableFrom(data.getClass());
+			return isIterable
+					? (Iterable<Object>) data
+					: Collections.singleton(data);
+		};
+	}
+
+	public ExpressionEvaluatorFactory<Object> getExpressionEvaluatorFactory() {
+		return object -> expression -> Optional.ofNullable(
+				JsonPath.using(JSONPATH_CONF).parse(object).read(expression));
+	}
+}

--- a/carml-engine/src/main/java/com/taxonic/carml/logical_source_resolver/LogicalSourceResolver.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/logical_source_resolver/LogicalSourceResolver.java
@@ -1,7 +1,8 @@
-package com.taxonic.carml.resolvers;
+package com.taxonic.carml.logical_source_resolver;
 
 import com.taxonic.carml.engine.EvaluateExpression;
 
+import java.io.InputStream;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -10,11 +11,11 @@ public interface LogicalSourceResolver<T> {
 	SourceIterator<T> getSourceIterator();
 	ExpressionEvaluatorFactory<T> getExpressionEvaluatorFactory();
 
-	default Supplier<Iterable<T>> bindSource(Object source, String iteratorExpression) {
+	default Supplier<Iterable<T>> bindSource(InputStream source, String iteratorExpression) {
 		return () -> getSourceIterator().apply(source, iteratorExpression);
 	}
 
-	interface SourceIterator<T> extends BiFunction<Object, String, Iterable<T>> {
+	interface SourceIterator<T> extends BiFunction<InputStream, String, Iterable<T>> {
 
 	}
 

--- a/carml-engine/src/main/java/com/taxonic/carml/logical_source_resolver/XPathResolver.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/logical_source_resolver/XPathResolver.java
@@ -1,0 +1,51 @@
+package com.taxonic.carml.logical_source_resolver;
+
+
+import com.sun.xml.internal.ws.util.xml.NodeListIterator;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.util.Optional;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+public class XPathResolver implements LogicalSourceResolver<Node> {
+
+	private XPath xpath = XPathFactory.newInstance().newXPath();
+
+	@Override
+	public SourceIterator<Node> getSourceIterator() {
+		return (inputStream, iteratorExpression) -> {
+			try {
+
+				DocumentBuilder documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+				Document doc = documentBuilder.parse(inputStream);
+				Object result = xpath.evaluate(iteratorExpression, doc, XPathConstants.NODESET);
+
+				return () -> new NodeListIterator((NodeList) result);
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		};
+	}
+
+	@Override
+	public ExpressionEvaluatorFactory<Node> getExpressionEvaluatorFactory() {
+		return entry -> expression -> {
+			try {
+				String result= xpath.evaluate(expression, entry);
+				return Optional.ofNullable(result);
+			} catch (XPathExpressionException e) {
+				throw new RuntimeException(e);
+			}
+		};
+	}
+
+}

--- a/carml-engine/src/main/java/com/taxonic/carml/resolvers/LogicalSourceResolver.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/resolvers/LogicalSourceResolver.java
@@ -6,18 +6,18 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-public abstract class LogicalSourceResolver<SourceType> {
-	public abstract SourceIterator<SourceType> getSourceIterator();
-	public abstract ExpressionEvaluatorFactory<SourceType> getExpressionEvaluatorFactory();
+public interface LogicalSourceResolver<T> {
+	SourceIterator<T> getSourceIterator();
+	ExpressionEvaluatorFactory<T> getExpressionEvaluatorFactory();
 
-	public Supplier<Iterable<SourceType>> bindSource(Object source, String iteratorExpression) {
+	default Supplier<Iterable<T>> bindSource(Object source, String iteratorExpression) {
 		return () -> getSourceIterator().apply(source, iteratorExpression);
 	}
 
-	public interface SourceIterator<SourceType> extends BiFunction<Object, String, Iterable<SourceType>> {
+	interface SourceIterator<T> extends BiFunction<Object, String, Iterable<T>> {
 
 	}
 
-	public interface ExpressionEvaluatorFactory<SourceType> extends Function<SourceType, EvaluateExpression> { }
+	interface ExpressionEvaluatorFactory<T> extends Function<T, EvaluateExpression> { }
 
 }

--- a/carml-engine/src/main/java/com/taxonic/carml/resolvers/LogicalSourceResolver.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/resolvers/LogicalSourceResolver.java
@@ -1,0 +1,23 @@
+package com.taxonic.carml.resolvers;
+
+import com.taxonic.carml.engine.EvaluateExpression;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public abstract class LogicalSourceResolver<SourceType> {
+	public abstract SourceIterator<SourceType> getSourceIterator();
+	public abstract ExpressionEvaluatorFactory<SourceType> getExpressionEvaluatorFactory();
+
+	public Supplier<Iterable<SourceType>> bindSource(Object source, String iteratorExpression) {
+		return () -> getSourceIterator().apply(source, iteratorExpression);
+	}
+
+	public interface SourceIterator<SourceType> extends BiFunction<Object, String, Iterable<SourceType>> {
+
+	}
+
+	public interface ExpressionEvaluatorFactory<SourceType> extends Function<SourceType, EvaluateExpression> { }
+
+}

--- a/carml-engine/src/test/java/com/taxonic/carml/engine/ParentTriplesMapperTest.java
+++ b/carml-engine/src/test/java/com/taxonic/carml/engine/ParentTriplesMapperTest.java
@@ -23,19 +23,18 @@ import org.mockito.junit.MockitoRule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import com.taxonic.carml.resolvers.LogicalSourceResolver;
+
 public class ParentTriplesMapperTest {
 	
 	@Mock
 	private TermGenerator<Resource> subjectGenerator;
 	
 	@Mock
-	private Supplier<Object> getSource;
+	private Supplier<Iterable<Object>> getIterator;
 	
 	@Mock
-	private UnaryOperator<Object> applyIterator;
-	
-	@Mock
-	private Function<Object, EvaluateExpression> expressionEvaluatorFactory;
+	private LogicalSourceResolver.ExpressionEvaluatorFactory expressionEvaluatorFactory;
 	
 	@Rule 
 	public MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -57,12 +56,10 @@ public class ParentTriplesMapperTest {
 
 	@Test
 	public void parentTriplesMapper_givenJoinConditions() {
-		when(getSource.get()).thenReturn("");
-		when(applyIterator.apply(""))
-			.thenReturn(ImmutableList.of(entry));
+		when(getIterator.get()).thenReturn(ImmutableList.of(entry));
 		when(expressionEvaluatorFactory.apply(entry)).thenReturn(evaluate);
 		when(subjectGenerator.apply(evaluate)).thenReturn(Optional.of(SKOS.CONCEPT));
-		ParentTriplesMapper mapper = new ParentTriplesMapper(subjectGenerator, getSource, applyIterator, expressionEvaluatorFactory);
+		ParentTriplesMapper mapper = new ParentTriplesMapper(subjectGenerator, getIterator, expressionEvaluatorFactory);
 		Set<Resource> resources = mapper.map(joinValues);
 		assertThat(resources.size(), is(1));
 		assertThat(SKOS.CONCEPT, isIn(resources));

--- a/carml-engine/src/test/java/com/taxonic/carml/engine/ParentTriplesMapperTest.java
+++ b/carml-engine/src/test/java/com/taxonic/carml/engine/ParentTriplesMapperTest.java
@@ -8,9 +8,7 @@ import static org.mockito.Mockito.when;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.vocabulary.SKOS;
@@ -23,7 +21,7 @@ import org.mockito.junit.MockitoRule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import com.taxonic.carml.resolvers.LogicalSourceResolver;
+import com.taxonic.carml.logical_source_resolver.LogicalSourceResolver;
 
 public class ParentTriplesMapperTest {
 	

--- a/carml-engine/src/test/java/com/taxonic/carml/engine/iotests/MappingTest.java
+++ b/carml-engine/src/test/java/com/taxonic/carml/engine/iotests/MappingTest.java
@@ -48,7 +48,9 @@ class MappingTest {
 		Consumer<RmlMapper> configureMapperInstance
 	) {
 		Set<TriplesMap> mapping = loader.load(rmlPath, RDFFormat.TURTLE);
-		RmlMapper.Builder builder = RmlMapper.newBuilder().classPathResolver(contextPath);
+		RmlMapper.Builder builder = RmlMapper.newBuilder()
+				.addDefaultLogicalSourceResolvers()
+				.classPathResolver(contextPath);
 		configureMapper.accept(builder);
 		RmlMapper mapper = builder.build();
 		configureMapperInstance.accept(mapper);

--- a/carml-engine/src/test/java/com/taxonic/carml/engine/iotests/RmlMapperTest.java
+++ b/carml-engine/src/test/java/com/taxonic/carml/engine/iotests/RmlMapperTest.java
@@ -175,7 +175,14 @@ public class RmlMapperTest extends MappingTest {
 					"RmlMapper/test2/subjectMapping.rml.ttl",
 					"RmlMapper/test2/subjectMapping.output.ttl");
 	}
-	
+
+	@Test
+	public void testXmlResolver() {
+		testMapping("RmlMapper",
+				"RmlMapper/xmlTest/mapping.ttl",
+				"RmlMapper/xmlTest/expected-output.ttl");
+	}
+
 	//TODO: PM: add test for rml:reference and rr:template where a value is not found.
 
 }

--- a/carml-engine/src/test/resources/RmlMapper/xmlTest/expected-output.ttl
+++ b/carml-engine/src/test/resources/RmlMapper/xmlTest/expected-output.ttl
@@ -1,0 +1,10 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix transit: <http://vocab.org/transit/terms/>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+
+<http://trans.example.com/25> rdf:type transit:Stop.
+<http://trans.example.com/25> transit:stop "645"^^xsd:int.
+<http://trans.example.com/25> rdfs:label "International Airport".
+# <http://trans.example.com/25> transit:stop "651"^^xsd:int.
+# <http://trans.example.com/25> rdfs:label "Conference center".

--- a/carml-engine/src/test/resources/RmlMapper/xmlTest/mapping.ttl
+++ b/carml-engine/src/test/resources/RmlMapper/xmlTest/mapping.ttl
@@ -1,0 +1,34 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#>.
+@prefix rml: <http://semweb.mmlab.be/ns/rml#>.
+@prefix ex: <http://example.com/ns#>.
+@prefix ql: <http://semweb.mmlab.be/ns/ql#>.
+@prefix transit: <http://vocab.org/transit/terms/>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+
+<#TransportMapping>
+  rml:logicalSource [
+    rml:source "xmlTest/transport.xml" ;
+    rml:iterator "/transport/bus";
+    rml:referenceFormulation ql:XPath;
+  ];
+
+  rr:subjectMap [
+    rr:template "http://trans.example.com/{@id}";
+    rr:class transit:Stop
+  ];
+
+  rr:predicateObjectMap [
+    rr:predicate transit:stop;
+    rr:objectMap [
+      rml:reference "./route/stop/@id";
+      rr:datatype xsd:int
+    ]
+  ];
+
+  rr:predicateObjectMap [
+    rr:predicate rdfs:label;
+    rr:objectMap [
+      rml:reference "./route/stop"
+    ]
+  ].

--- a/carml-engine/src/test/resources/RmlMapper/xmlTest/transport.xml
+++ b/carml-engine/src/test/resources/RmlMapper/xmlTest/transport.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This example is copied from http://rml.io/spec.html#example-XML -->
+<transport>
+    <bus id="25">
+        <route>
+            <stop id="645">International Airport</stop>
+            <!--<stop id="651">Conference center</stop>-->
+        </route>
+    </bus>
+</transport>


### PR DESCRIPTION
This branch is based on [branch 9-decouple-ref-formulation](/kvoskuil/carml/tree/9-decouple-ref-formulation). It adds an XPath resolver.

I also added a test based on [the xml example in the spec](http://rml.io/spec.html#example-XML), but had to make some changes. First, the xpath expressions in the mapping were absolute and contained syntax errors. Second (and I'm less sure about this part), the example iterates over busses, and each bus contains multple `<stop>`s. In the example, two triples for each stop are generated, but this does not make sense to me. I simplified the example to have just one stop.