### PR TITLE
Allow join in case of multiple parent values

### DIFF
--- a/carml-engine/pom.xml
+++ b/carml-engine/pom.xml
@@ -46,6 +46,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
@@ -66,7 +66,7 @@ class ParentTriplesMapper<T> {
 				expressionEvaluatorFactory.apply(entry);
 
 		boolean joinsValid = joinValues.stream()
-				.allMatch(j -> isValidJoin(entry, j));
+				.allMatch(j -> isValidJoin(evaluate, j));
 
 		if (joinsValid) {
 			LOG.trace("Valid join found for entry with join {}", joinValues);
@@ -76,7 +76,7 @@ class ParentTriplesMapper<T> {
 		return ImmutableList.of();
 	}
 
-	private boolean isValidJoin(T entry, Pair<String, Object> joinValue) {
+	private boolean isValidJoin(EvaluateExpression evaluate, Pair<String, Object> joinValue) {
 		LOG.trace("Determining validity of join {}", joinValue);
 		String parentExpression = joinValue.getLeft();
 
@@ -84,8 +84,6 @@ class ParentTriplesMapper<T> {
 		LOG.trace("Extracting join's children {}", childItems);
 		Set<String> children = extractValues(childItems);
 
-		EvaluateExpression evaluate =
-				expressionEvaluatorFactory.apply(entry);
 		Optional<Object> parentValue = evaluate.apply(parentExpression);
 		if (LOG.isTraceEnabled()) {
 			LOG.trace("with result: {}", parentValue.orElse("null"));

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
@@ -87,7 +87,7 @@ class ParentTriplesMapper<T> {
 		EvaluateExpression evaluate =
 				expressionEvaluatorFactory.apply(entry);
 		Optional<Object> parentValue = evaluate.apply(parentExpression);
-		if (LOG.isTraceEnabled()) { // TODO flogger?
+		if (LOG.isTraceEnabled()) {
 			LOG.trace("with result: {}", parentValue.orElse("null"));
 		}
 

--- a/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
+++ b/carml-engine/src/main/java/com/taxonic/carml/engine/ParentTriplesMapper.java
@@ -91,13 +91,15 @@ class ParentTriplesMapper<T> {
 
 		return parentValue.map(v -> {
 			if (v instanceof Collection<?>) {
-				// we could use just the if-case, but we keep the else-case as a performance optimization
+				// if the intersection of parent and child values is non-empty, the join is valid
 				Set<String> parentValues = extractValues(v);
 				return !SetUtils.intersection(parentValues, children).isEmpty();
 			} else {
 				// If one of the child values matches, the join is valid.
 				return children.contains(String.valueOf(v));
 			}
+			// using only the above if-case would be logically equivalent here,
+			// but we keep the if/else as a performance optimization
 		}).orElse(false);
 	}
 

--- a/carml-engine/src/test/java/com/taxonic/carml/engine/iotests/MappingTest.java
+++ b/carml-engine/src/test/java/com/taxonic/carml/engine/iotests/MappingTest.java
@@ -86,4 +86,10 @@ class MappingTest {
 //		System.out.println(writer.toString());
 //	}
 
+//	private void setCommonNamespaces(Model model) {
+//		model.setNamespace("dct", "http://purl.org/dc/terms/");
+//		model.setNamespace("foaf", "http://xmlns.com/foaf/0.1/");
+//		model.setNamespace("rdfs", "http://www.w3.org/2000/01/rdf-schema#");
+//		model.setNamespace("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
+//	}
 }

--- a/carml-engine/src/test/java/com/taxonic/carml/engine/iotests/RmlMapperTest.java
+++ b/carml-engine/src/test/java/com/taxonic/carml/engine/iotests/RmlMapperTest.java
@@ -153,6 +153,13 @@ public class RmlMapperTest extends MappingTest {
 	}
 
 	@Test
+	public void testJoinOnMultipleParentValues() {
+		testMapping("RmlMapper",
+			"RmlMapper/test19/joinOnMultipleParentValues.rml.ttl",
+			"RmlMapper/test19/joinOnMultipleParentValues.output.ttl");
+	}
+
+	@Test
 	public void testSeparateMapsMapping() {
 		testMapping("RmlMapper",
 				"RmlMapper/test10/separateMapsMapping.rml.ttl",

--- a/carml-engine/src/test/resources/RmlMapper/authorsWithBooks.json
+++ b/carml-engine/src/test/resources/RmlMapper/authorsWithBooks.json
@@ -1,0 +1,27 @@
+{
+  "authors": [{
+    "name": "John Johnson",
+    "books": [{
+      "id": 29,
+      "title": "Ultimate Pancakes"
+    }, {
+      "id": 45,
+      "title": "Ultimate Ravioli"
+    }, {
+      "id": 60,
+      "title": "Ultimate Broccoli: A Feast for the Ages"
+    }]
+  }, {
+    "name": "Jack Jackson",
+    "books": [{
+      "id": 2028,
+      "title": "Flying Airplanes"
+    }, {
+      "id": 2070,
+      "title": "Riding Bicycles"
+    }, {
+      "id": 2091,
+      "title": "Driving Cars: A World Beyond"
+    }]
+  }]
+}

--- a/carml-engine/src/test/resources/RmlMapper/test19/joinOnMultipleParentValues.output.ttl
+++ b/carml-engine/src/test/resources/RmlMapper/test19/joinOnMultipleParentValues.output.ttl
@@ -1,0 +1,44 @@
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex: <http://www.example.com/> .
+@prefix lit: <http://www.example.com/lit/> .
+@prefix book: <http://www.example.com/book/> .
+@prefix author: <http://www.example.com/author/> .
+
+book:29 a lit:Book ;
+	dct:identifier "29" ;
+	rdfs:label "Ultimate Pancakes" ;
+	lit:author author:John%20Johnson .
+
+book:45 a lit:Book ;
+	dct:identifier "45" ;
+	rdfs:label "Ultimate Ravioli" ;
+	lit:author author:John%20Johnson .
+
+book:60 a lit:Book ;
+	dct:identifier "60" ;
+	rdfs:label "Ultimate Broccoli: A Feast for the Ages" ;
+	lit:author author:John%20Johnson .
+
+book:2028 a lit:Book ;
+	dct:identifier "2028" ;
+	rdfs:label "Flying Airplanes" ;
+	lit:author author:Jack%20Jackson .
+
+book:2070 a lit:Book ;
+	dct:identifier "2070" ;
+	rdfs:label "Riding Bicycles" ;
+	lit:author author:Jack%20Jackson .
+
+book:2091 a lit:Book ;
+	dct:identifier "2091" ;
+	rdfs:label "Driving Cars: A World Beyond" ;
+	lit:author author:Jack%20Jackson .
+
+author:John%20Johnson a lit:Author ;
+  foaf:name "John Johnson" .
+
+author:Jack%20Jackson a lit:Author ;
+  foaf:name "Jack Jackson" .

--- a/carml-engine/src/test/resources/RmlMapper/test19/joinOnMultipleParentValues.rml.ttl
+++ b/carml-engine/src/test/resources/RmlMapper/test19/joinOnMultipleParentValues.rml.ttl
@@ -1,0 +1,63 @@
+@prefix ex: <http://www.example.com/>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix carml: <http://carml.taxonic.com/carml/> .
+@prefix : <http://www.example.com/mapping/> .
+@prefix lit: <http://www.example.com/lit/> .
+
+:books
+  rml:logicalSource [
+    rml:source "authorsWithBooks.json" ;
+    rml:referenceFormulation ql:JSONPath ;
+    rml:iterator "$.authors[*].books[*]" ;
+  ];
+  rr:subjectMap [
+    rr:template "http://www.example.com/book/{id}" ;
+    rr:class lit:Book ;
+  ];
+  rr:predicateObjectMap [
+    rr:predicate dct:identifier ;
+    rr:objectMap [
+      rml:reference "id" ;
+    ]
+  ];
+  rr:predicateObjectMap [
+    rr:predicate rdfs:label ;
+    rr:objectMap [
+      rml:reference "title" ;
+    ]
+  ];
+  rr:predicateObjectMap [
+    rr:predicate lit:author;
+    rr:objectMap [
+      rr:parentTriplesMap :authors;
+      rr:joinCondition [
+        rr:parent "$.books[*].id";
+        rr:child "id";
+      ];
+    ];
+  ];
+.
+
+:authors
+  rml:logicalSource [
+    rml:source "authorsWithBooks.json" ;
+    rml:referenceFormulation ql:JSONPath ;
+    rml:iterator "$.authors[*]" ;
+  ];
+  rr:subjectMap [
+    rr:template "http://www.example.com/author/{name}" ;
+    rr:class lit:Author;
+  ];
+  rr:predicateObjectMap [
+    rr:predicate foaf:name;
+    rr:objectMap [
+      rml:reference "name";
+    ]
+  ];
+.

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<rdf4j.version>3.4.0</rdf4j.version>
 		<commons-lang3.version>3.11</commons-lang3.version>
+		<commons-collections4.version>4.4</commons-collections4.version>
 		<commons-io.version>2.7</commons-io.version>
 		<slf4j.version>1.7.30</slf4j.version>
 		<guava.version>29.0-jre</guava.version>
@@ -168,6 +169,12 @@
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
 				<version>${commons-lang3.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-collections4</artifactId>
+				<version>${commons-collections4.version}</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
Allow joining when parent expression in join condition results in multiple values. Previously, this would result in an error with message `Parent expression [{expression}] in join condition leads to multiple values. This is not supported.`

A join is made if the intersection of the sets of parent and child values is non-empty.

This functionality is needed to realize a join in the case where child items have no reference to the parent item, but the parent item _does_ contain a set of values that refer to its child items. Example input data:
```
{
  "authors": [{
    "name": "John Johnson",
    "books": [{
      "id": 2971,
      ...
    }, {
      ...
    }]
  }]
}
```
In the above, a book has no reference to its author, since JSON path does not support navigating "up". However, from an author, a set of book ids can be obtained through `$.books[*].id`, allowing the following join to succeed:
```
rr:joinCondition [
  rr:parent "$.books[*].id";
  rr:child "id";
];
```