### PR TITLE
fix CarmlMapper for TermMaps

### DIFF
--- a/carml-rdf-mapper/src/main/java/io/carml/rdfmapper/impl/CarmlMapper.java
+++ b/carml-rdf-mapper/src/main/java/io/carml/rdfmapper/impl/CarmlMapper.java
@@ -472,13 +472,33 @@ public class CarmlMapper implements Mapper, MappingCache {
         MethodPropertyHandlerRegistry.Builder regBuilder = MethodPropertyHandlerRegistry.builder();
 
         regBuilder.method(method);
-        RdfProperty[] annotations = method.getAnnotationsByType(RdfProperty.class);
+        var annotations = getRdfPropertyAnnotations(method, clazz);
 
-        Arrays.stream(annotations)
-                .forEach(annotation ->
-                        collectRdfPropertyHandler(annotation, method, clazz, regBuilder, model, resource));
+        annotations.forEach(annotation ->
+                collectRdfPropertyHandler(annotation, method, clazz, regBuilder, model, resource));
 
         return regBuilder.isBuildable() ? regBuilder.build().getEffectiveHandlers(model, resource) : Stream.empty();
+    }
+
+    private List<RdfProperty> getRdfPropertyAnnotations(Method method, Class<?> clazz) {
+        List<RdfProperty> annotations = new ArrayList<>();
+        collectRdfPropertyAnnotations(clazz, method.getName(), method.getParameterTypes(), annotations);
+        return annotations;
+    }
+
+    private void collectRdfPropertyAnnotations(Class<?> clazz, String methodName, Class<?>[] parameterTypes, List<RdfProperty> annotations) {
+        Objects.requireNonNull(clazz);
+
+        try {
+            Method declaredMethod = clazz.getDeclaredMethod(methodName, parameterTypes);
+            RdfProperty[] classAnnotations = declaredMethod.getAnnotationsByType(RdfProperty.class);
+            annotations.addAll(List.of(classAnnotations));
+        } catch (NoSuchMethodException ignored) {
+        }
+
+        if (clazz.getSuperclass() != null)
+            collectRdfPropertyAnnotations(clazz.getSuperclass(), methodName, parameterTypes, annotations);
+        // TODO: Maybe we also need to look at interfaces if we annotate at that level ?
     }
 
     private void collectRdfPropertyHandler(

--- a/carml-rml-rdf-object-loader-test/pom.xml
+++ b/carml-rml-rdf-object-loader-test/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.carml</groupId>
+        <artifactId>carml</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>carml-rml-rdf-object-loader-test</artifactId>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+
+    <dependencies>
+
+        <dependency>
+            <groupId>io.carml</groupId>
+            <artifactId>carml-commons</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.carml</groupId>
+            <artifactId>carml-model</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.carml</groupId>
+            <artifactId>carml-logical-source-resolver-jsonpath</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-sail-memory</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
+    </dependencies>
+
+
+</project>

--- a/carml-rml-rdf-object-loader-test/src/test/java/RdfRmlLoaderTest.java
+++ b/carml-rml-rdf-object-loader-test/src/test/java/RdfRmlLoaderTest.java
@@ -1,0 +1,125 @@
+import io.carml.model.FilePath;
+import io.carml.model.Template;
+import io.carml.model.impl.*;
+import io.carml.rdfmapper.util.RdfObjectLoader;
+import io.carml.util.RmlNamespaces;
+import io.carml.vocab.Rdf;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class RdfRmlLoaderTest {
+
+    private static final ValueFactory VF = SimpleValueFactory.getInstance();
+    private Model model;
+
+
+    public void prepareTest(String resource, RDFFormat rdfFormat) {
+        try (InputStream input = RdfRmlLoaderTest.class.getResourceAsStream(resource)) {
+            model = Rio.parse(input, "", rdfFormat);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void givenSubjectMapInTurtle_whenMap_thenReturnMappedSubjectMapWithTemplate() {
+        // Given
+        prepareTest("mapping.ttl", RDFFormat.TURTLE);
+
+        // When
+        var subjects = RdfObjectLoader.load(
+                model -> Set.of(VF.createIRI("http://example.com/base/NameSubjectMap")),
+                CarmlSubjectMap.class,
+                model,
+                m -> m,
+                mappingCache -> {
+                },
+                mapper -> {
+                },
+                RmlNamespaces.RML_NAMESPACES);
+
+        // Then
+        assertThat(subjects, hasSize(1));
+        var namedSubjectMap = subjects.iterator().next();
+        assertThat(namedSubjectMap.getTemplate(), isA(Template.class));
+
+        var segments = namedSubjectMap.getTemplate().getSegments();
+        assertThat(segments, hasSize(2));
+        Template.Segment firstSegment = segments.get(0);
+        Template.Segment secondSegment = segments.get(1);
+
+        assertThat(firstSegment, isA(CarmlTemplate.TextSegment.class));
+        assertThat(firstSegment.getValue(), is("http://example.com/"));
+
+        assertThat(secondSegment, isA(CarmlTemplate.ExpressionSegment.class));
+        assertThat(secondSegment.getValue(), is("$.Name"));
+    }
+
+
+    @Test
+    void givenObjectMapInTurtle_whenMap_thenReturnMappedObjectMapWithReference() {
+        // Given
+        prepareTest("mapping.ttl", RDFFormat.TURTLE);
+
+        // When
+        var subjects = RdfObjectLoader.load(
+                model -> Set.of(VF.createIRI("http://example.com/base/NameObjectMap")),
+                CarmlObjectMap.class,
+                model,
+                m -> m,
+                mappingCache -> {
+                },
+                mapper -> {
+                },
+                RmlNamespaces.RML_NAMESPACES);
+
+        // Then
+        assertThat(subjects, hasSize(1));
+        var namedSubjectMap = subjects.iterator().next();
+        assertThat(namedSubjectMap.getReference(), is("$.Name"));
+    }
+
+    @Test
+    void givenRmlMapping_whenMap_thenReturnMappedCarmlModelObjects() {
+        // Given
+        prepareTest("mapping.ttl", RDFFormat.TURTLE);
+
+        // When
+        var triplesMap = RdfObjectLoader.load(
+                model -> Set.of(VF.createIRI("http://example.com/base/TriplesMap1")),
+                CarmlTriplesMap.class,
+                model,
+                m -> m,
+                mappingCache -> {
+                },
+                mapper -> mapper.addDecidableType(Rdf.Rml.FilePath, FilePath.class)
+                        .bindInterfaceImplementation(FilePath.class, CarmlFilePath.class),
+                RmlNamespaces.RML_NAMESPACES);
+
+        // Then
+        assertThat(triplesMap, hasSize(1));
+        var tm = triplesMap.iterator().next();
+        assertThat(tm.getLogicalSource(), is(notNullValue()));
+        assertThat(tm.getSubjectMaps(), hasSize(1));
+        var subjectMap = tm.getSubjectMaps().iterator().next();
+        assertThat(subjectMap.getTemplate(), notNullValue());
+
+        // Check predicate object map with reference value
+        assertThat(tm.getPredicateObjectMaps(), hasSize(1));
+        var predicateObjectMap = tm.getPredicateObjectMaps().iterator().next();
+        assertThat(predicateObjectMap.getObjectMaps(), hasSize(1));
+        var objectMap = predicateObjectMap.getObjectMaps().iterator().next();
+        assertThat(objectMap, notNullValue());
+    }
+}

--- a/carml-rml-rdf-object-loader-test/src/test/resources/mapping.ttl
+++ b/carml-rml-rdf-object-loader-test/src/test/resources/mapping.ttl
@@ -1,0 +1,21 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rml:  <http://w3id.org/rml/> .
+@prefix ex:   <http://example.com/base/> .
+
+ex:TriplesMap1
+    a                      rml:TriplesMap ;
+    rml:logicalSource      [
+                             rml:iterator             "$.students[*]" ;
+                             rml:referenceFormulation rml:JSONPath ;
+                             rml:source               [ a        rml:FilePath ;
+                                                        rml:root rml:MappingDirectory ;
+                                                        rml:path "student.json" ] ] ;
+    rml:predicateObjectMap [ rml:objectMap    ex:NameObjectMap ;
+                             rml:predicateMap [ rml:constant foaf:name ] ] ;
+    rml:subjectMap         ex:NameSubjectMap .
+
+ex:NameSubjectMap
+    rml:template "http://example.com/{$.Name}" .
+
+ex:NameObjectMap
+    rml:reference "$.Name" .

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,8 @@
 		<module>carml-converters-jena</module>
 		<module>carml-serializer-jena</module>
     <module>carml-test-cases</module>
-  </modules>
+        <module>carml-rml-rdf-object-loader-test</module>
+    </modules>
 
 	<properties>
 		<maven.compiler.release>17</maven.compiler.release>


### PR DESCRIPTION
Hello @pmaria 

I was testing CARML and had a strange issue that the `SubjectMap` or `ObjectMap` were having all of their fields null without the reference/template they should have; I was using Java 25 temurin if that matters.

Turns out the `getReference()` method is declared in one of the superclasses (`ExpressionMap`), and the annotations are only available on the direct class (`ObjectMap`/`SubjectMap`) declaration, and the `@Inherit` meta-annotation works only on classes, sadly not methods, so I suggest collecting annotations on all the inheritance tree.

The carml-rml-rdf-object-loader-test module is for some tests I used to understand it. 
I can remove or rename it if you prefer.